### PR TITLE
add history manager for all persistent structures

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,15 +1,37 @@
 package com.github.mihanizzm
 
+import com.github.mihanizzm.model.PersistentHistory
 import com.github.mihanizzm.model.map.PathCopyingPersistentMap
 
 fun main() {
     val squares = PathCopyingPersistentMap<Int, Int>()
+    val squaresHistory = PersistentHistory(squares)
 
     var i = 0
     val resultMap = generateSequence { i += 1; i }
         .take(1000)
-        .fold(squares) { acc, i -> acc.put(i, i * i) as PathCopyingPersistentMap<Int, Int> }
+        .fold(squares) { _, i ->
+            squaresHistory.update(squaresHistory.cur().put(i, i * i))
+        }
 
     println("${resultMap[0]}, ${resultMap[9]}, ${resultMap[42]}, ${resultMap[99]}, ${resultMap[731]}")
     println("Height: ${resultMap.treeHeight()}")
+
+    println(squaresHistory.cur()[12])
+    println(squaresHistory.cur()[1000])
+    println(squaresHistory.undo()[1000])
+    println(squaresHistory.redo()[1000])
+
+    squaresHistory.update(squaresHistory.cur().put(1, 42))
+    println(squaresHistory.cur()[1])
+
+    squaresHistory.update(squaresHistory.cur().put(1, 17))
+    println(squaresHistory.cur()[1])
+
+    println(squaresHistory.undo()[1])
+    println(squaresHistory.undo()[1])
+
+    squaresHistory.update(squaresHistory.cur().put(1, 22))
+    println(squaresHistory.canRedo())
+    println(squaresHistory.redo()[1])
 }

--- a/src/main/kotlin/model/PersistentHistory.kt
+++ b/src/main/kotlin/model/PersistentHistory.kt
@@ -1,0 +1,31 @@
+package com.github.mihanizzm.model
+
+class PersistentHistory<T>(initial: T) {
+    private val history = mutableListOf(initial)
+    private var pointer = 0
+
+    fun cur(): T = history[pointer]
+
+    fun update(newVersion: T): T {
+        if (pointer < history.lastIndex) {
+            history.subList(pointer + 1, history.size).clear()
+        }
+        history.add(newVersion)
+        pointer++
+        return cur()
+    }
+
+    fun undo(): T {
+        if (pointer > 0) pointer--
+        return cur()
+    }
+
+    fun redo(): T {
+        if (pointer < history.lastIndex) pointer++
+        return cur()
+    }
+
+    fun canUndo() = pointer > 0
+    fun canRedo() = pointer < history.lastIndex
+}
+

--- a/src/main/kotlin/model/map/PathCopyingPersistentMap.kt
+++ b/src/main/kotlin/model/map/PathCopyingPersistentMap.kt
@@ -27,7 +27,7 @@ class PathCopyingPersistentMap<K: Comparable<K>, V> private constructor(
         return null
     }
 
-    override fun put(key: K, value: V): PersistentMap<K, V> {
+    override fun put(key: K, value: V): PathCopyingPersistentMap<K, V> {
         var added = false
         fun putRec(node: Node<K, V>?): Node<K, V> {
             if (node == null) {
@@ -44,7 +44,7 @@ class PathCopyingPersistentMap<K: Comparable<K>, V> private constructor(
         return PathCopyingPersistentMap(newRoot, if (added) size + 1 else size)
     }
 
-    override fun remove(key: K): PersistentMap<K, V> {
+    override fun remove(key: K): PathCopyingPersistentMap<K, V> {
         var removed = false
         fun findMin(node: Node<K, V>): Node<K, V> =
             node.left?.let { findMin(it) } ?: node


### PR DESCRIPTION
Сделал класс, реализующий менеджер версий для всех персистентных структур данных проекта, если они хранят версию как ссылку на какой-либо ее элемент. В случае наших реализаций на path copying алгоритме, эта реализация должна хорошо работать со всеми структурами.